### PR TITLE
kzpro checkpoints not allowed

### DIFF
--- a/addons/sourcemod/scripting/kztimer/commands.sp
+++ b/addons/sourcemod/scripting/kztimer/commands.sp
@@ -1786,9 +1786,9 @@ public DoCheckpoint(client)
 {
 	if (!g_bAllowCheckpoints || IsFakeClient(client) || !IsValidClient(client) || !IsPlayerAlive(client) || GetClientTeam(client) == 1 || g_bPause[client]) 
 		return;
-			
-	if (StrEqual("kzpro", g_szMapPrefix[0]) && g_bTimeractivated[client])	
-		return;			
+		
+	if (StrEqual("kzpro", g_szMapPrefix[0]) && g_bTimeractivated[client])
+		return;
 		
 	if (!g_bChallenge_Checkpoints[client] && g_bChallenge[client])
 	{

--- a/addons/sourcemod/scripting/kztimer/timer.sp
+++ b/addons/sourcemod/scripting/kztimer/timer.sp
@@ -170,9 +170,6 @@ public Action:KZTimer1(Handle:timer)
 	if (g_bRoundEnd)
 		return Plugin_Continue;
 		
-	if (g_bAllowCheckpoints && (StrEqual("kzpro", g_szMapPrefix[0])))
-		ServerCommand("kz_checkpoints 0");
-		
 	decl client;
 	for (client = 1; client <= MaxClients; client++)
 	{		


### PR DESCRIPTION
dont set kz_checkpoints to 0 on kzpro maps. Whenever doing a checkpoint
its already checking if the map is kzpro and since a kzpro map can have
a longjump room we dont want to disallow checkpoints at all.
